### PR TITLE
ENH: pass on python style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/

--- a/expes/main_core.py
+++ b/expes/main_core.py
@@ -17,8 +17,9 @@ if __name__ == '__main__':
     # --------------------------- #
 
     # observations, features, sparsity
-    m, n, non_zeros = 500, 10000, 100
+    m, n, non_zeros = 500, 1000, 10
     # MM TODO: we could use n_samples, n_features instead of m and n
+    # TB: TODO: it is ok with me
 
     # x true
     xstar = 5
@@ -34,7 +35,8 @@ if __name__ == '__main__':
     c_lam = 0.7
 
     # set alpha
-    # MM TODO: maybe l1_ratio is a more explicit name ?
+    # TODO MM: maybe l1_ratio is a more explicit name ?
+    # TODO TB: I prefer to leave it is consistent with the paper notation
     alpha = 0.9
 
     # to choose between cg and exact method
@@ -74,13 +76,14 @@ if __name__ == '__main__':
 
     # compute err variance and error
     # TODO: MM: can we use np.std here ?
-    err_sd = np.sqrt(np.var(np.dot(A, x_true)) / snr)
+    # TODO: TB: YES
+    err_sd = np.std(A @ x_true) / np.sqrt(snr)
     err = err_sd * np.random.normal(0, 1, (m, ))
 
     # compute the response
     b = np.dot(A, x_true).reshape(m, ) + err
     # b = np.dot(A, x_true).reshape(m, )
-    b += - np.mean(b)
+    b -= np.mean(b)
 
     # find lam1_max, and determine lam1 and lam2
     Atb = A.T @ b
@@ -100,3 +103,4 @@ if __name__ == '__main__':
         step_reduce=step_reduce, mu=mu, tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
         maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
         use_cg=use_cg, r_exact=r_exact, print_lev=print_lev)
+

--- a/expes/main_datasets.py
+++ b/expes/main_datasets.py
@@ -1,19 +1,13 @@
-
-# ------------------- #
-#                     #
-#    Realdata Main    #
-#                     #
-# ------------------- #
+"""Run solver on real data"""
 
 
 import numpy as np
-import time
 from sklearn.preprocessing import PolynomialFeatures
 from scipy.linalg import eigh as largest_eigh
 from numpy import linalg as LA
 
 
-from ssnal import ssnal_elastic_path, ssnal_elastic_core
+from ssnal import ssnal_elastic_core
 
 if __name__ == '__main__':
 
@@ -84,18 +78,18 @@ if __name__ == '__main__':
     poly = PolynomialFeatures(poly_degree)
     A = poly.fit_transform(A)[:, 1:]
     A = (A - A.mean(axis=0)) / A.std(axis=0)
-    b = b - b.mean(axis=0)
+    b -= b.mean(axis=0)
     m, n = A.shape
 
     print('')
     print('  * dim A =', A.shape)
     print('  * max_lam(AAt) = %.4e' %
-          largest_eigh(np.dot(A, A.transpose()), eigvals=(m - 1, m - 1))[0][0])
+          largest_eigh(np.dot(A, A.T), eigvals=(m - 1, m - 1))[0][0])
+    # TODO MM use np.linalg.norm(A, ord=2) ** 2?
     print('')
 
     # find lam1_max, and determine lam1 and lam2
-    Atb = np.dot(A.transpose(), b)
-    lam1_max = LA.norm(Atb, np.inf) / alpha
+    lam1_max = LA.norm(A.T @ b, ord=np.inf) / alpha
     lam1 = alpha * c_lam * lam1_max
     lam2 = (1 - alpha) * c_lam * lam1_max
 
@@ -105,12 +99,9 @@ if __name__ == '__main__':
 
     print('')
     print('  * start ssnal_elastic')
-    out_core = ssnal_elastic_core(A=A, b=b,
-                                  lam1=lam1, lam2=lam2,
-                                  x0=None, y0=None, z0=None, Aty0=None,
-                                  sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
-                                  step_reduce=step_reduce, mu=mu,
-                                  tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
-                                  maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
-                                  use_cg=use_cg, r_exact=r_exact,
-                                  print_lev=print_lev)
+    out_core = ssnal_elastic_core(
+        A=A, b=b, lam1=lam1, lam2=lam2, x0=None, y0=None, z0=None, Aty0=None,
+        sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
+        step_reduce=step_reduce, mu=mu, tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
+        maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
+        use_cg=use_cg, r_exact=r_exact, print_lev=print_lev)

--- a/expes/main_datasets.py
+++ b/expes/main_datasets.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
     print('  * max_lam(AAt) = %.4e' %
           largest_eigh(np.dot(A, A.T), eigvals=(m - 1, m - 1))[0][0])
     # TODO MM use np.linalg.norm(A, ord=2) ** 2?
+    # TODO TB largest_eigh is more efficient. With a 1000x1000 matrix it took 0.3 sec while np.linalg.norm took 1.7sec
     print('')
 
     # find lam1_max, and determine lam1 and lam2

--- a/expes/main_path.py
+++ b/expes/main_path.py
@@ -1,23 +1,14 @@
-
-# ---------------------------------------------- #
-#                                                #
-#    Run ssnal_elastic_tune on synthetic data    #
-#                                                #
-# ---------------------------------------------- #
-
+"""Compute ElasticNet path with SSNAL algorithm."""
 
 
 import numpy as np
 from numpy import linalg as LA
-import time
 from scipy.linalg import eigh as largest_eigh
 
 from ssnal import ssnal_elastic_path
 
 
 if __name__ == '__main__':
-
-    # seed = np.random.randint(0, 1e5)
     seed = 54
     np.random.seed(seed)
 
@@ -25,14 +16,8 @@ if __name__ == '__main__':
     #  set simulation parameters  #
     # --------------------------- #
 
-    # observations
-    m = 500
-
-    # features
-    n = 10000
-
-    # sparsity
-    non_zeros = 10
+    # observations, features, sparsity
+    m, n, non_zeros = 500, 10_000, 10
 
     # x true
     xstar = 5
@@ -42,11 +27,10 @@ if __name__ == '__main__':
 
     # --------------------- #
     #  set ssnal_parameter  #
-    # --------------------- #
+    # --------------------- ##
 
     # set a vector with lam1_max percentages to consider
-    # c_lam_vec = np.linspace(start=1, stop=0.1, num=40)
-    c_lam_vec = np.logspace(start=3, stop=2, num=100) / 1000
+    c_lam_vec = np.geomspace(1, 0.1, num=100)
 
     # alpha
     alpha = 0.6
@@ -93,7 +77,6 @@ if __name__ == '__main__':
     print('')
     print('  * generating A')
     A = np.random.normal(0, 1, (m, n))
-    # print('  * max_lam(AAt) / n = %.4e' % (largest_eigh(np.dot(A, A.transpose()), eigvals=(m - 1, m - 1))[0][0] / n))
     print('')
 
     # compute true coefficients
@@ -106,28 +89,20 @@ if __name__ == '__main__':
 
     # compute the response
     b = np.dot(A, x_true).reshape(m, ) + err
-    b += - np.mean(b)
-
-    # # find lam_max
-    # lam1_max = LA.norm(np.dot(A.transpose(), b), np.inf) / alpha
+    b -= np.mean(b)
 
     # -------------------- #
     #  ssnal elastic path  #
     # -------------------- #
 
-    out_path = ssnal_elastic_path(A=A, b=b,
-                                  c_lam_vec=c_lam_vec, alpha=alpha,
-                                  max_selected=max_selected,
-                                  cv=cv, n_folds=n_folds,
-                                  x0=None, y0=None, z0=None, Aty0=None,
-                                  sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
-                                  step_reduce=step_reduce, mu=mu,
-                                  tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
-                                  maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
-                                  use_cg=use_cg, r_exact=r_exact,
-                                  plot=plot, print_lev=print_lev)
+    out_path = ssnal_elastic_path(
+        A=A, b=b, c_lam_vec=c_lam_vec, alpha=alpha, max_selected=max_selected,
+        cv=cv, n_folds=n_folds, x0=None, y0=None, z0=None, Aty0=None,
+        sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
+        step_reduce=step_reduce, mu=mu, tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
+        maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
+        use_cg=use_cg, r_exact=r_exact, plot=plot, print_lev=print_lev)
 
-    
     # ------------------------------------ #
     #  if I want to test different alphas  #
     # ------------------------------------ #
@@ -159,6 +134,3 @@ if __name__ == '__main__':
     #
     # import auxiliary_functions as AF
     # AF.plot_cv_ssnal_elstic(r_lm_list, ebic_list, gcv_list, cv_vec_list, alpha_vec, c_lam_vec)
-
-
-    

--- a/expes/main_path.py
+++ b/expes/main_path.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     x_true[0:non_zeros] = xstar
 
     # compute err variance and error
-    err_sd = np.sqrt(np.var(np.dot(A, x_true)) / snr)
+    err_sd = np.std(A @ x_true) / np.sqrt(snr)
     err = err_sd * np.random.normal(0, 1, (m, ))
 
     # compute the response

--- a/ssnal/auxiliary_functions.py
+++ b/ssnal/auxiliary_functions.py
@@ -7,29 +7,22 @@
 # -------------------------------------------------------------- #
 
 
+import matplotlib.pyplot as plt
 import numpy as np
 from numpy import linalg as LA
 import matplotlib
 matplotlib.use('TkAgg')
-import matplotlib.pyplot as plt
 
 
 def prox_elst(v, par1, par2):
-
-    """
-    computes proximal operator for elastic net penalization
-
-    """
-
+    """Compute proximal operator for elastic net penalization"""
     if par2 > 0:
-        return 1 / (1 + par2) * (np.maximum(0, v - par1) - np.maximum(0, - v - par1))
-
+        return (np.maximum(0, v - par1) - np.maximum(0, - v - par1)) / (1 + par2)
     else:
         return np.maximum(0, v - par1) - np.maximum(0, - v - par1)
 
 
 def prox_star_elst(v, par1, par2, t):
-
     """
     computes proximal operator for the conjugate of the elastic net penalization
 
@@ -41,11 +34,7 @@ def prox_star_elst(v, par1, par2, t):
 
 
 def p_star_elst(v, par1, par2):
-
-    """
-    computes the conjugate function of the elastic net penalization
-
-    """
+    """computes the conjugate function of the elastic net penalization"""
 
     if par2 > 0:
         return np.sum(np.maximum(0, v - par1) ** 2 + np.maximum(0, - v - par1) ** 2) / (2 * par2)
@@ -55,39 +44,30 @@ def p_star_elst(v, par1, par2):
 
 
 def prim_obj_elst(A, x, b, lam1, lam2):
+    """computes primal object of the elastic net"""
 
-    """
-    computes primal object of the elastic net
-
-    """
-
-    return 0.5 * LA.norm(np.dot(A, x) - b) ** 2 + lam1 * LA.norm(x, 1) + lam2 / 2 * LA.norm(x) ** 2
+    return (0.5 * LA.norm(A @ x - b) ** 2 + lam1 * LA.norm(x, 1) +
+            lam2 / 2 * LA.norm(x) ** 2)
 
 
 def dual_obj_elst(y, z, b, lam1, lam2):
+    """compute dual objective of the elastic net"""
 
-    """
-    computes dual object of the elastic net
-
-    """
-
-    return - (0.5 * LA.norm(y) ** 2 + np.dot(b.transpose(), y) + p_star_elst(z, lam1, lam2))
+    return - (0.5 * LA.norm(y) ** 2 + b.T @ y + p_star_elst(z, lam1, lam2))
 
 
 def phi_y_elst(y, x, b, Aty, sgm, lam1, lam2):
-
     """
     computes phi(y) for the elastic net problem
 
     """
 
-    return (LA.norm(y) ** 2 / 2 + np.dot(b.transpose(), y) +
-           (1 + sgm * lam2) / (2 * sgm) * LA.norm(prox_elst(x - sgm * Aty, sgm * lam1, sgm * lam2)) ** 2 -
+    return (LA.norm(y) ** 2 / 2 + b.T @ y +
+            (1 + sgm * lam2) / (2 * sgm) * LA.norm(prox_elst(x - sgm * Aty, sgm * lam1, sgm * lam2)) ** 2 -
             LA.norm(x) ** 2 / (2 * sgm))
 
 
 def grad_phi_elst(A, y, x, b, Aty, sgm, lam1, lam2):
-
     """
     computes the gradient of phi(y) for the elastic net problem
 
@@ -97,30 +77,25 @@ def grad_phi_elst(A, y, x, b, Aty, sgm, lam1, lam2):
 
 
 def factorization(A, sgm):
-
     """
     computes cholesky factorization of:
         I + sgm * A'A   if r > m
         I + sgm * AA'   if r<= m  (SWM formula)
-
     """
 
     m, r = A.shape
-    At = A.transpose()
 
     if m >= r:  # special case, SWW formula
-        A_star = 1 / sgm * np.eye(r) + np.dot(At, A)
+        A_star = 1 / sgm * np.eye(r) + A.T @ A
     else:
-        A_star = np.eye(m) + sgm * np.dot(A, At)
+        A_star = np.eye(m) + sgm * A @ A.T
 
     L = LA.cholesky(A_star)
-    Lt = L.transpose()
 
-    return L, Lt
+    return L, L.T
 
 
 def plot_cv_ssnal_elstic(r_lm, ebic, gcv, cv, alpha, grid):
-
     """
     plots of: r_lm, ebic, gcv, cv for different values of alpha
 
@@ -158,7 +133,8 @@ def plot_cv_ssnal_elstic(r_lm, ebic, gcv, cv, alpha, grid):
     for i in range(n_alpha):
         indx = ebic_list[i] != -1
         t = grid[:ebic_list[i].shape[0]][indx]
-        ax[0, 0].plot(t, ebic_list[i][indx], label=('alpha = %.2f' % alpha_vec[i]))
+        ax[0, 0].plot(t, ebic_list[i][indx], label=(
+            'alpha = %.2f' % alpha_vec[i]))
     ax[0, 0].legend(loc='best')
     ax[0, 0].set_title('ebic')
     ax[0, 0].set_xlim([grid[0], grid[-1]])
@@ -167,7 +143,8 @@ def plot_cv_ssnal_elstic(r_lm, ebic, gcv, cv, alpha, grid):
     for i in range(n_alpha):
         indx = gcv_list[i] != -1
         t = grid[:gcv_list[i].shape[0]][indx]
-        ax[0, 1].plot(t, gcv_list[i][indx], label=('alpha = %.2f' % alpha_vec[i]))
+        ax[0, 1].plot(t, gcv_list[i][indx], label=(
+            'alpha = %.2f' % alpha_vec[i]))
     ax[0, 1].legend(loc='best')
     ax[0, 1].set_title('gcv')
     ax[0, 1].set_xlim([grid[0], grid[-1]])
@@ -176,7 +153,8 @@ def plot_cv_ssnal_elstic(r_lm, ebic, gcv, cv, alpha, grid):
     for i in range(n_alpha):
         indx = r_lm_list[i] != -1
         t = grid[:r_lm_list[i].shape[0]][indx]
-        ax[1, 0].plot(t, r_lm_list[i][indx], label=('alpha = %.2f' % alpha_vec[i]))
+        ax[1, 0].plot(t, r_lm_list[i][indx], label=(
+            'alpha = %.2f' % alpha_vec[i]))
     ax[1, 0].legend(loc='best')
     ax[1, 0].set_title('selected features')
     ax[1, 0].set_xlim([grid[0], grid[-1]])
@@ -186,11 +164,10 @@ def plot_cv_ssnal_elstic(r_lm, ebic, gcv, cv, alpha, grid):
         for i in range(n_alpha):
             indx = cv_list[i] != -1
             t = grid[:cv_list[i].shape[0]][indx]
-            ax[1, 1].plot(t, cv_list[i][indx], label=('alpha = %.2f' % alpha_vec[i]))
+            ax[1, 1].plot(t, cv_list[i][indx], label=(
+                'alpha = %.2f' % alpha_vec[i]))
         ax[1, 1].legend(loc='best')
         ax[1, 1].set_title('cross validation')
         ax[1, 1].set_xlim([grid[0], grid[-1]])
 
     plt.show()
-
-

--- a/ssnal/elastic_path.py
+++ b/ssnal/elastic_path.py
@@ -42,7 +42,7 @@ def ssnal_elastic_path(A, b,
     :param x0: initial value for the lagrangian multiplier (variable of the primal problem) (n, ) -- vector 0 if not given
     :param y0: initial value fot the first variable of the dual problem  (m, ) -- vector of 0 if not given
     :param z0: initial value for the second variable of the dual problem (n, ) -- vector of 0 if not given
-    :param Aty0: np.dot(A.transpose(), y0) (n,)
+    :param Aty0: np.dot(A.T, y0) (n,)
     :param max_selected: maximum number of features selected
     :param cv: True/False. I true, a cross validation is performed
     :param n_folds: number of folds to perform the cross validation
@@ -92,7 +92,7 @@ def ssnal_elastic_path(A, b,
     :return[12] convergence_ssnal: True/False. If true, the ssnal has converged
     :return[13] ssnal_time: total time of ssnal
     :return[14] it_ssnal: total ssnal's iteration
-    :return[15] Aty: np.dot(A.transpose(), y) computed at the optimal y. Useful to implement warmstart
+    :return[15] Aty: np.dot(A.T, y) computed at the optimal y. Useful to implement warmstart
     --------------------------------------------------------------------------------------------------
 
     """
@@ -103,20 +103,20 @@ def ssnal_elastic_path(A, b,
 
     m, n = A.shape
 
-    lam1_max = LA.norm(np.dot(A.transpose(), b), np.inf) / alpha
+    lam1_max = LA.norm(A.T @ b, ord=np.inf) / alpha
 
     if x0 is None:
-        x0 = np.zeros((n,))
+        x0 = np.zeros(n)
     if y0 is None:
-        y0 = np.zeros((m,))
+        y0 = np.zeros(m)
     if z0 is None:
-        z0 = np.zeros((n,))
+        z0 = np.zeros(n)
 
     if max_selected is None:
         max_selected = n
 
     if c_lam_vec is None:
-        c_lam_vec = np.logspace(start=3, stop=1, num=100, base=10.0)/1000
+        c_lam_vec = np.geomspace(1, 0.01, num=100)
 
     n_lam1 = c_lam_vec.shape[0]
 
@@ -169,14 +169,13 @@ def ssnal_elastic_path(A, b,
         #    perform ssnal    #
         # ------------------- #
 
-        fit = ssnal_elastic_core(A=A, b=b, lam1=lam1, lam2=lam2,
-                                 x0=x0, y0=y0, z0=z0, Aty0=Aty0,
-                                 sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
-                                 step_reduce=step_reduce, mu=mu,
-                                 tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
-                                 maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
-                                 use_cg=use_cg, r_exact=r_exact,
-                                 print_lev=print_lev - 3)
+        fit = ssnal_elastic_core(
+            A=A, b=b, lam1=lam1, lam2=lam2, x0=x0, y0=y0, z0=z0, Aty0=Aty0,
+            sgm=sgm, sgm_increase=sgm_increase, sgm_change=sgm_change,
+            step_reduce=step_reduce, mu=mu, tol_ssn=tol_ssn,
+            tol_ssnal=tol_ssnal, maxiter_ssn=maxiter_ssn,
+            maxiter_ssnal=maxiter_ssnal, use_cg=use_cg, r_exact=r_exact,
+            print_lev=print_lev - 3)
 
         # ----------------------- #
         #    check convergence    #
@@ -281,14 +280,14 @@ def ssnal_elastic_path(A, b,
                 #    perform ssnal    #
                 # ------------------- #
 
-                fit_cv = ssnal_elastic_core(A=A_train, b=b_train, lam1=lam1, lam2=lam2,
-                                            x0=x0_cv, y0=y0_cv, z0=z0_cv, Aty0=Aty0_cv,
-                                            sgm=sgm_cv, sgm_increase=sgm_increase, sgm_change=sgm_change,
-                                            step_reduce=step_reduce, mu=mu,
-                                            tol_ssn=tol_ssn, tol_ssnal=tol_ssnal,
-                                            maxiter_ssn=maxiter_ssn, maxiter_ssnal=maxiter_ssnal,
-                                            use_cg=use_cg, r_exact=r_exact,
-                                            print_lev=0)
+                fit_cv = ssnal_elastic_core(
+                    A=A_train, b=b_train, lam1=lam1, lam2=lam2, x0=x0_cv,
+                    y0=y0_cv, z0=z0_cv, Aty0=Aty0_cv, sgm=sgm_cv,
+                    sgm_increase=sgm_increase, sgm_change=sgm_change,
+                    step_reduce=step_reduce, mu=mu, tol_ssn=tol_ssn,
+                    tol_ssnal=tol_ssnal, maxiter_ssn=maxiter_ssn,
+                    maxiter_ssnal=maxiter_ssnal, use_cg=use_cg,
+                    r_exact=r_exact, print_lev=0)
 
                 # ------------------- #
                 #    update cv mat    #


### PR DESCRIPTION
Hi @tobiaboschi 
transposing an array is free in numpy (it just creates a view, data is not copied). using array.T is more idiomatic and reads more like maths than .transpose() IMO.
Same goes for using @ instead of np.dot 

There were some unused import (running pylint can catch these; there are still quite a few lines longer than 80 characters to) 

np.zeros(100) works fine, no need to np.zeros((100,)) (lighter syntax)

you can use np.geomspace to get geometric sequences


I ran the examples again and it seemed fine, but can you check carefully that I did not introduced an error in the maths?